### PR TITLE
Update ListHelper.cs

### DIFF
--- a/source/XrmLibrary.EntityHelpers/Marketing/ListHelper.cs
+++ b/source/XrmLibrary.EntityHelpers/Marketing/ListHelper.cs
@@ -437,7 +437,7 @@ namespace XrmLibrary.EntityHelpers.Marketing
             {
                 foreach (var item in data.Entities)
                 {
-                    name = isStatic ? ((AliasedValue)item[nameAttribute]).Value.ToString() : item.GetAttributeValue<string>(nameAttribute);
+                    name = isStatic ? item.GetAttributeValue<AliasedValue>(nameAttribute)?.Value.ToString() : item.GetAttributeValue<string>(nameAttribute);
                     result.Add(membertype, new ListMemberItemDetail(item.Id, name));
                 }
             }
@@ -452,7 +452,7 @@ namespace XrmLibrary.EntityHelpers.Marketing
                 {
                     foreach (var item in data.Entities)
                     {
-                        name = isStatic ? ((AliasedValue)item[nameAttribute]).Value.ToString() : item.GetAttributeValue<string>(nameAttribute);
+                        name = isStatic ? item.GetAttributeValue<AliasedValue>(nameAttribute)?.Value.ToString() : item.GetAttributeValue<string>(nameAttribute);
                         result.Add(membertype, new ListMemberItemDetail(item.Id, name));
                     }
                 }


### PR DESCRIPTION
When a member is missing the name attribute (AliasedValue)item[nameAttribute] will cause a "The given key was not present in the dictionary" error.